### PR TITLE
Enable POA support via --poa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 build/
 dist/
 wheels/
+misc/
 *.egg-info
 
 # Virtual environments

--- a/accounts.py
+++ b/accounts.py
@@ -21,7 +21,8 @@ class AccountKeyType(Enum):
     def get_vkey(self) -> str:
         """
         Returns the vkey string based on the AccountKeyType instance.
-        The vkey is a string key used to identify ValidatorId
+        The vkey is a string key used to identify ValidatorId which here is either
+        the ecdsa pub key or ss58 address
         """
         match self:
             case AccountKeyType.AccountId20:

--- a/chainspec_handlers.py
+++ b/chainspec_handlers.py
@@ -9,6 +9,7 @@ Then include your handler in the main script before `start_network()` is called
 import json
 
 from accounts import AccountKeyType
+from config import Config
 
 
 def load_chainspec(chainspec: str):
@@ -121,3 +122,29 @@ def edit_account_balances(
     data["genesis"]["runtimeGenesis"]["patch"]["balances"]["balances"] = balances
     # Write the modified data back to the original file
     write_chainspec(chainspec, data)
+
+
+def enable_poa(chainspec: str, config: Config):
+    data = load_chainspec(chainspec)
+    # Add PoA specific configurations
+    aura_authorities = []
+    gran_authorities = []
+    for node in config.nodes:
+        entry_aura = node["aura-ss58"]
+        aura_authorities.append(entry_aura)
+        entry_grandpa = [node["grandpa-ss58"], 1]
+        gran_authorities.append(entry_grandpa)
+
+    data["genesis"]["runtimeGenesis"]["patch"]["aura"]["authorities"] = aura_authorities
+    data["genesis"]["runtimeGenesis"]["patch"]["grandpa"]["authorities"] = (
+        gran_authorities
+    )
+    # Write the modified data back to the original file
+    write_chainspec(chainspec, data)
+
+
+def enable_custom(chainspec: str, config: Config):
+    """
+    Modify the chainspec for custom network configuration.
+    """
+    pass

--- a/chainspec_handlers.py
+++ b/chainspec_handlers.py
@@ -143,8 +143,17 @@ def enable_poa(chainspec: str, config: Config):
     write_chainspec(chainspec, data)
 
 
-def enable_custom(chainspec: str, config: Config):
+def custom_network_config(chainspec: str, config: Config):
     """
     Modify the chainspec for custom network configuration.
     """
-    pass
+    edit_vs_ss_authorities(
+        chainspec, config.nodes, config.account_key_type
+    )  # Custom handler for a particular chain using substrate-validator-set and pallet-session
+    edit_account_balances(
+        chainspec,
+        config.nodes,
+        config.account_key_type,
+        removeExisting=True,  # Remove Existing balances
+        amount=5234,  # Balance
+    )  # Custom handler for setting balances genesis

--- a/config.py
+++ b/config.py
@@ -93,7 +93,7 @@ def parse_args() -> Config:
     )
     parser.add_argument(
         "--poa",
-        type=bool,
+        action="store_true",
         default=False,
         help="Enable Substrate-node-template PoA mode, i.e. assign all authorities equal weight in chainspec",
     )

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 import argparse
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import List, Dict
 
 from accounts import AccountKeyType
 
@@ -12,8 +13,38 @@ class Config:
     root_dir: str = "./network"
     clean: bool = False
     chainspec: str = "dev"
+    raw_chainspec: str = None
     bin: str = "substrate"
     account_key_type: AccountKeyType = AccountKeyType.AccountId20
+    poa: bool = False
+    nodes: List[Dict] = field(
+        default_factory=lambda: [
+            {
+                "name": "alice",
+                "p2p-port": 30333,
+                "rpc-port": 9944,
+                "prometheus-port": 9615,
+            },
+            {
+                "name": "bob",
+                "p2p-port": 30334,
+                "rpc-port": 9945,
+                "prometheus-port": 9616,
+            },
+            {
+                "name": "charlie",
+                "p2p-port": 30335,
+                "rpc-port": 9946,
+                "prometheus-port": 9617,
+            },
+            {
+                "name": "david",
+                "p2p-port": 30336,
+                "rpc-port": 9947,
+                "prometheus-port": 9618,
+            },
+        ]
+    )
 
 
 def parse_args() -> Config:
@@ -60,6 +91,12 @@ def parse_args() -> Config:
         default=AccountKeyType.AccountId20,
         help="Type of account key ('ecdsa' for Ethereum-style, 'sr25519' for Substrate-style)",
     )
+    parser.add_argument(
+        "--poa",
+        type=bool,
+        default=False,
+        help="Enable Substrate-node-template PoA mode, i.e. assign all authorities equal weight in chainspec",
+    )
 
     args = parser.parse_args()
     # !! WARNING: argsparse will actually set non-supplied flags to None! This works for boolean values but
@@ -73,4 +110,5 @@ def parse_args() -> Config:
         chainspec=args.chainspec,
         bin=os.path.abspath(args.bin),
         account_key_type=args.account,
+        poa=args.poa,
     )

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import time
 import sys
 import shutil
 from accounts import AccountKeyType
-from chainspec_handlers import edit_account_balances, edit_vs_ss_authorities, enable_poa
+from chainspec_handlers import custom_network_config, enable_poa
 from config import parse_args, Config
 from ethereum import generate_ethereum_keypair
 
@@ -364,19 +364,11 @@ def main(config: Config):
         CHAINSPEC
     )  # Initializes ROOT_DIR/chainspec.json
     if config.poa:
+        # Compatible with substrate proof-of-authority type setups where session key is (aura, grandpa)
         enable_poa(chainspec, config)
     else:
-        # Custom Network Configuration
-        edit_vs_ss_authorities(
-            chainspec, NODES, config.account_key_type
-        )  # Custom handler for a particular chain using substrate-validator-set and pallet-session
-        edit_account_balances(
-            chainspec,
-            NODES,
-            config.account_key_type,
-            removeExisting=True,  # Remove Existing balances
-            amount=5234,  # Balance
-        )  # Custom handler for setting balances genesis
+        # Custom Network Configuration - define your own
+        custom_network_config(chainspec, config)
     if RUN_NETWORK:
         if INTERACTIVE:
             proceed = (

--- a/main.py
+++ b/main.py
@@ -6,18 +6,11 @@ import time
 import sys
 import shutil
 from accounts import AccountKeyType
-from chainspec_handlers import edit_account_balances, edit_vs_ss_authorities
+from chainspec_handlers import edit_account_balances, edit_vs_ss_authorities, enable_poa
 from config import parse_args, Config
 from ethereum import generate_ethereum_keypair
 
-global INTERACTIVE, RUN_NETWORK, SUBSTRATE, ROOT_DIR, CHAINSPEC
-
-NODES = [
-    {"name": "alice", "p2p-port": 30333, "rpc-port": 9944, "prometheus-port": 9615},
-    {"name": "bob", "p2p-port": 30334, "rpc-port": 9945, "prometheus-port": 9616},
-    {"name": "charlie", "p2p-port": 30335, "rpc-port": 9946, "prometheus-port": 9617},
-    {"name": "david", "p2p-port": 30336, "rpc-port": 9947, "prometheus-port": 9618},
-]
+global INTERACTIVE, RUN_NETWORK, SUBSTRATE, ROOT_DIR, CHAINSPEC, NODES
 
 
 def run_command(command, cwd=None):
@@ -199,7 +192,7 @@ def setup_dirs():
         node["base_path"] = f"{ROOT_DIR}/{node['name']}"
 
 
-def init_chainspec(chainspec):
+def init_bootnodes_chainspec(chainspec):
     """Generate a new chainspec and insert bootnodes into it
     If chainspec file is provided as arg, that's used as template instead of generating a new one.
     This function is required to be called before other chainspec editing functions
@@ -249,7 +242,7 @@ def generate_raw_chainspec(chainspec: str) -> str:
     Returns:
         str: The path to the generated raw chainspec file.
     """
-    raw_chainspec_path = f"{ROOT_DIR}/raw_chainspec.json"
+    raw_chainspec_path = os.path.join(ROOT_DIR, "raw_chainspec.json")
     try:
         result = subprocess.run(
             [
@@ -267,6 +260,7 @@ def generate_raw_chainspec(chainspec: str) -> str:
         with open(raw_chainspec_path, "w") as f:
             f.write(result.stdout)
         print(f"Raw chainspec written to {raw_chainspec_path}")
+        config.raw_chainspec = raw_chainspec_path
         return raw_chainspec_path
     except subprocess.CalledProcessError as e:
         raise Exception(f"Failed to generate raw chainspec: {e.stderr}")
@@ -366,17 +360,23 @@ def main(config: Config):
     else:
         insert_keystore(CHAINSPEC)
     # Modified chainspec with bootnodes inserted
-    chainspec = init_chainspec(CHAINSPEC)  # Initializes ROOT_DIR/chainspec.json
-    edit_vs_ss_authorities(
-        chainspec, NODES, config.account_key_type
-    )  # Custom handler for a particular chain using substrate-validator-set and pallet-session
-    edit_account_balances(
-        chainspec,
-        NODES,
-        config.account_key_type,
-        removeExisting=True,  # Remove Existing balances
-        amount=5234,  # Balance
-    )  # Custom handler for setting balances genesis
+    chainspec = init_bootnodes_chainspec(
+        CHAINSPEC
+    )  # Initializes ROOT_DIR/chainspec.json
+    if config.poa:
+        enable_poa(chainspec, config)
+    else:
+        # Custom Network Configuration
+        edit_vs_ss_authorities(
+            chainspec, NODES, config.account_key_type
+        )  # Custom handler for a particular chain using substrate-validator-set and pallet-session
+        edit_account_balances(
+            chainspec,
+            NODES,
+            config.account_key_type,
+            removeExisting=True,  # Remove Existing balances
+            amount=5234,  # Balance
+        )  # Custom handler for setting balances genesis
     if RUN_NETWORK:
         if INTERACTIVE:
             proceed = (
@@ -399,6 +399,7 @@ if __name__ == "__main__":
     ROOT_DIR = config.root_dir
     SUBSTRATE = config.bin
     CHAINSPEC = config.chainspec
+    NODES = config.nodes
 
     # Validate root-dir
     if not os.path.exists(config.root_dir):


### PR DESCRIPTION
- Abstract chainspec configuration into one of `custom_network_config` (for custom nodes) or standard `enable_poa` for node-templates. This is useful because most nodes start from node-templates, like polkadot-evm/frontier/template or substrate-node-template
- custom_network_config takes care of chainspec edits for special nodes where you've changed the genesis structure by introducing a staking system or the session pallets such as I have used, with `edit_vs_ss..` function to edit a node-spec using substrate-validator-set in conjunction with pallet-sessions

Use `--poa` to start a poa multi-node-setup and make sure the node you use has those features;
Also keep in mind if you use the template from `polkadot-evm/frontier/template` you might not need to pass in `--account ecdsa` as it's the default but for a normal substrate-node-template you must pass in `--account sr25519` in order to avoid problems. 